### PR TITLE
add ES6 module name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.4",
   "description": "Simple ORM to manage and query your state trees",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "jest --coverage",
     "prepublish": "npm run build",


### PR DESCRIPTION
This tells ES6-aware code builders to use the source directly rather than the transpired versions.  It is primarily a fix for #53 but may have other benefits.